### PR TITLE
alter CC

### DIFF
--- a/SimpleSimulator/components/CC.py
+++ b/SimpleSimulator/components/CC.py
@@ -25,7 +25,7 @@ cycle_number = []
 memory_tracker = []
 
 def trackMemory(mem_address):
-    cycle_number.append(cycle_number)
+    cycle_number.append(cyclecounter)
     memory_tracker.append(mem_address)
 
 def trackerGraph():

--- a/SimpleSimulator/simulator.py
+++ b/SimpleSimulator/simulator.py
@@ -28,10 +28,10 @@ while not halted:
 
     instruction = components.MEM.getData(components.PC.PC)
 
+    new_PC,halted=components.EE.execute(instruction)
+
     components.CC.trackMemory(components.PC.PC)
     components.CC.cyclecounter += 1
-
-    new_PC,halted=components.EE.execute(instruction)
 
     components.PC.dump()
     components.RF.dump()


### PR DESCRIPTION
remove numpy import
input x and y for scatterplot are now normal lists
cyclecounter variable keeps track of the number of cycles completed
this update has been made to keep track of multiple memory access in a single cycle.